### PR TITLE
feat: add path helper utilities

### DIFF
--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -22,11 +22,19 @@ Note:
 from .text_sanitizer import (
     normalize_spaces,
     normalize_to_string,
-    remove_all_whitespace
+    remove_all_whitespace,
+)
+from .path_helpers import (
+    join,
+    normalize,
+    project_root,
 )
 
 __all__ = [
     "normalize_spaces",
     "normalize_to_string",
-    "remove_all_whitespace"
+    "remove_all_whitespace",
+    "join",
+    "normalize",
+    "project_root",
 ]

--- a/src/utils/path_helpers.py
+++ b/src/utils/path_helpers.py
@@ -1,0 +1,139 @@
+"""Utility helpers for working with filesystem paths.
+
+This module centralizes small wrappers around :mod:`os.path` to provide a
+consistent, cross‑platform interface for path manipulation.  All helpers use
+`os.path` under the hood which automatically applies the correct path
+separators on Windows, macOS and Linux.
+
+Functions
+---------
+join(*parts: str) -> str
+    Concatenate path fragments using the operating system's separator.
+normalize(path: str) -> str
+    Collapse redundant separators and resolve user home markers.
+project_root(start: str) -> str
+    Walk upwards from ``start`` until a project root marker is found.
+"""
+
+from __future__ import annotations
+
+import os
+
+
+def join(*parts: str) -> str:
+    """Join multiple path components using :func:`os.path.join`.
+
+    Parameters
+    ----------
+    *parts:
+        Arbitrary path components.  Empty strings are ignored in the same way
+        as :func:`os.path.join`.
+
+    Returns
+    -------
+    str
+        The combined path.
+
+    Notes
+    -----
+    This function is primarily a thin wrapper that explicitly documents the
+    project's intent to use :mod:`os.path` for cross‑platform path handling.
+    No validation of path existence is performed.
+    """
+
+    return os.path.join(*parts)
+
+
+def normalize(path: str) -> str:
+    """Normalize a filesystem path.
+
+    The function expands the user home directory (``~``) and collapses
+    redundant separators and relative references.
+
+    Parameters
+    ----------
+    path:
+        A filesystem path.  It may be relative or absolute.
+
+    Returns
+    -------
+    str
+        A normalized path string.
+
+    Raises
+    ------
+    TypeError
+        If ``path`` is not a string.
+
+    Notes
+    -----
+    The result is not guaranteed to point to an existing location.  The
+    behavior of :func:`os.path.normpath` is platform specific; for example,
+    Windows drive letters and UNC paths are preserved.
+    """
+
+    if not isinstance(path, str):  # Guard against common programmer errors.
+        raise TypeError("path must be a string")
+
+    # ``expanduser`` handles ``~`` and is safe on all supported platforms.
+    expanded = os.path.expanduser(path)
+    normalized = os.path.normpath(expanded)
+    return normalized
+
+
+def project_root(start: str) -> str:
+    """Locate the project root directory.
+
+    Starting at ``start`` (which may be a file or directory), this function
+    walks up the directory tree until it encounters a marker that identifies the
+    project's root.  Recognized markers are a ``.git`` directory or a
+    ``pyproject.toml`` file.
+
+    Parameters
+    ----------
+    start:
+        The path from which to begin searching.  If a file path is provided it
+        is interpreted relative to its containing directory.
+
+    Returns
+    -------
+    str
+        Absolute path to the discovered project root directory.
+
+    Raises
+    ------
+    FileNotFoundError
+        If no project root markers are found before reaching the filesystem
+        root.
+
+    Notes
+    -----
+    The search resolves symbolic links and is safe on both Windows and POSIX
+    filesystems.  The existence of the marker files/directories is checked, but
+    no further validation of the directory's contents is performed.
+    """
+
+    if not isinstance(start, str):
+        raise TypeError("start must be a string")
+
+    path = os.path.abspath(start)
+    if os.path.isfile(path):
+        path = os.path.dirname(path)
+
+    markers = (".git", "pyproject.toml")
+
+    while True:
+        for marker in markers:
+            if os.path.exists(os.path.join(path, marker)):
+                return path
+
+        parent = os.path.dirname(path)
+        if parent == path:
+            raise FileNotFoundError(
+                f"No project root markers found starting from '{start}'"
+            )
+        path = parent
+
+
+__all__ = ["join", "normalize", "project_root"]
+

--- a/tests/utils/test_path_helpers.py
+++ b/tests/utils/test_path_helpers.py
@@ -1,0 +1,72 @@
+"""Unit tests for filesystem path helper utilities.
+
+This module exercises the small helpers in ``src.utils.path_helpers`` to ensure
+consistent behaviour across operating systems and edge cases.
+
+The tests cover:
+
+* ``join`` – cross‑platform concatenation of path fragments.
+* ``normalize`` – collapsing redundant separators and expanding ``~``.
+* ``project_root`` – discovery of the repository root and error handling when
+  no markers are present.
+
+Example Usage
+-------------
+    # From project root
+    python -m unittest tests/utils/test_path_helpers.py
+
+Dependencies
+------------
+* Python >= 3.9
+* Standard Library: unittest, tempfile, os
+
+Notes
+-----
+* These tests rely solely on the public API exported by ``src.utils``.
+"""
+
+import os
+import tempfile
+import unittest
+
+from src.utils import join, normalize, project_root
+
+
+class TestPathHelpers(unittest.TestCase):
+
+    def test_join(self):
+        """Ensures wrapper mirrors :func:`os.path.join` semantics."""
+        parts = ["foo", "bar", "baz"]
+        expected = os.path.join(*parts)
+        self.assertEqual(join(*parts), expected)
+
+    def test_normalize(self):
+        """Verify tilde expansion and separator normalization."""
+        raw = os.path.join("~", "some", "..", "folder")
+        expected = os.path.normpath(os.path.expanduser(raw))
+        self.assertEqual(normalize(raw), expected)
+
+    def test_project_root_from_file(self):
+        """Detect repository root starting from a file path."""
+        # Compute expected root using os.path directly for test isolation.
+        path = os.path.abspath(__file__)
+        expected = path
+        while True:
+            expected = os.path.dirname(expected)
+            if os.path.exists(os.path.join(expected, ".git")):
+                break
+
+        self.assertEqual(project_root(__file__), expected)
+
+    def test_project_root_not_found(self):
+        """Raise ``FileNotFoundError`` when no marker exists."""
+        with tempfile.TemporaryDirectory() as tmp:
+            nested = os.path.join(tmp, "a", "b")
+            os.makedirs(nested)
+            with self.assertRaises(FileNotFoundError):
+                project_root(nested)
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- add cross-platform path helper utilities and expose through `src.utils`
- cover path helpers with unit tests

## Testing
- `python -m pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_688e7788b340832287a41a6f800ff31a